### PR TITLE
drop support for Julia 1.0 & 1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.2'
           - '1'
           - 'nightly'
         os:


### PR DESCRIPTION
the latest test package management framework was introduced in 1.2.